### PR TITLE
Fix: Replace Console Transport with File Transports to Prevent Memory Issues

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -37,9 +37,14 @@ export const logger = createLogger({
   ),
   transports: [
     // TODO Make transport configurable
-    // new transports.File({filename: 'error.log', level: 'error'}),
-    // new transports.File({filename: 'combined.log'}),
+    //
+    // - Write all logs with importance level of `error` or less to `error.log`
+    // - Write all logs with importance level of `info` or less to `combined.log`
+    //
+    new winston.transports.File({ filename: 'error.log', level: 'error' }),
+    new winston.transports.File({ filename: 'combined.log' }),
+
+    // causes high memory usage. do not use in production
     // new transports.Console()
-    new winston.transports.File({ filename: 'turnserver-healthckeck.log' })
   ]
 });

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -39,6 +39,7 @@ export const logger = createLogger({
     // TODO Make transport configurable
     // new transports.File({filename: 'error.log', level: 'error'}),
     // new transports.File({filename: 'combined.log'}),
-    new transports.Console()
+    // new transports.Console()
+    new winston.transports.File({ filename: 'turnserver-healthckeck.log' })
   ]
 });


### PR DESCRIPTION
This PR addresses a memory issue caused by the usage of the Console transport in production environments. According to the official documentation, using the Console transport in production is not recommended due to potential high memory usage.

### Changes Made
- Removed the Console transport.
- Added two File transports to handle logging:
  - `error.log`: Logs messages with an importance level of `error` or less.
  - `combined.log`: Logs messages with an importance level of `info` or less.

Testing
Verified that logs are correctly written to error.log and combined.log.
Confirmed that memory usage remains stable in a production-like environment.
Additional Notes
Please review the changes and let me know if there are any concerns or suggestions for further improvement.
